### PR TITLE
Fix TypeScript build configuration for web package

### DIFF
--- a/packages/games/src/index.ts
+++ b/packages/games/src/index.ts
@@ -1,4 +1,5 @@
-import { createSharedContext, SharedContext } from '@pvp-games/shared';
+import { createSharedContext } from '@pvp-games/shared';
+import type { SharedContext } from '@pvp-games/shared';
 import { DuelSnakeGame } from './duel-snake';
 
 export interface GameSummary {
@@ -28,3 +29,4 @@ export function getGameSummaries(): GameSummary[] {
 }
 
 export { DuelSnakeGame };
+export type { Direction, DuelSnakeState, PlayerId } from './duel-snake';

--- a/packages/games/tsconfig.json
+++ b/packages/games/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src", "tests"],
+  "include": ["src"],
+  "exclude": ["tests"],
   "references": [
     { "path": "../shared" }
   ]

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src", "tests"],
+  "include": ["src"],
+  "exclude": ["tests"],
   "references": [
     { "path": "../shared" }
   ]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src", "tests"],
+  "include": ["src"],
+  "exclude": ["tests"],
   "references": []
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,6 +20,7 @@
     "@testing-library/jest-dom": "^6.4.1",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^24.10.1",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { Direction, DuelSnakeState, PlayerId } from '@pvp-games/games/src/duel-snake';
-import { DuelSnakeGame } from '@pvp-games/games/src/duel-snake';
+import type { Direction, DuelSnakeState, PlayerId } from '@pvp-games/games';
+import { DuelSnakeGame } from '@pvp-games/games';
 import './app.css';
 
 type KeyBinding = {
@@ -99,8 +99,12 @@ export function App() {
 
   const width = state.dimensions.width;
   const height = state.dimensions.height;
-  const p1Cells = new Set(state.players.p1.segments.map((cell) => `${cell.x},${cell.y}`));
-  const p2Cells = new Set(state.players.p2.segments.map((cell) => `${cell.x},${cell.y}`));
+  const p1Cells = new Set(
+    state.players.p1.segments.map((cell: DuelSnakeState['players']['p1']['segments'][number]) => `${cell.x},${cell.y}`)
+  );
+  const p2Cells = new Set(
+    state.players.p2.segments.map((cell: DuelSnakeState['players']['p2']['segments'][number]) => `${cell.x},${cell.y}`)
+  );
   const fruitKey = `${state.fruit.x},${state.fruit.y}`;
 
   return (

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -2,10 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist/types",
-    "moduleResolution": "NodeNext",
-    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "paths": {
@@ -14,6 +12,7 @@
     }
   },
   "include": ["src", "vite.config.ts", "vitest.config.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**", "vite-config.test.ts"],
   "references": [
     { "path": "../games" }
   ]

--- a/packages/web/tsconfig.vitest.json
+++ b/packages/web/tsconfig.vitest.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "types": ["vitest/globals", "vitest/importMeta", "@testing-library/jest-dom"]
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
+  "exclude": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(jsdom@24.1.3)
+        version: 1.6.1(@types/node@24.10.1)(jsdom@24.1.3)
 
   packages/games:
     dependencies:
@@ -26,7 +26,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(jsdom@24.1.3)
+        version: 1.6.1(@types/node@24.10.1)(jsdom@24.1.3)
 
   packages/server:
     dependencies:
@@ -39,7 +39,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(jsdom@24.1.3)
+        version: 1.6.1(@types/node@24.10.1)(jsdom@24.1.3)
 
   packages/shared:
     devDependencies:
@@ -48,7 +48,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(jsdom@24.1.3)
+        version: 1.6.1(@types/node@24.10.1)(jsdom@24.1.3)
 
   packages/web:
     dependencies:
@@ -71,6 +71,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@9.3.4)
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
       '@types/react':
         specifier: ^18.3.10
         version: 18.3.27
@@ -79,7 +82,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.7.0(vite@5.4.21)
+        version: 4.7.0(vite@5.4.21(@types/node@24.10.1))
       jsdom:
         specifier: ^24.1.1
         version: 24.1.3
@@ -88,10 +91,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.3.1
-        version: 5.4.21
+        version: 5.4.21(@types/node@24.10.1)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(jsdom@24.1.3)
+        version: 1.6.1(@types/node@24.10.1)(jsdom@24.1.3)
 
 packages:
 
@@ -528,6 +531,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@24.10.1':
+    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1265,6 +1271,9 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -1774,6 +1783,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.27)':
@@ -1785,7 +1798,7 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@24.10.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -1793,7 +1806,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@24.10.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2601,6 +2614,8 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  undici-types@7.16.0: {}
+
   universalify@0.2.0: {}
 
   update-browserslist-db@1.1.4(browserslist@4.28.0):
@@ -2614,13 +2629,13 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  vite-node@1.6.1:
+  vite-node@1.6.1(@types/node@24.10.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@24.10.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -2632,15 +2647,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@24.10.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.53.3
     optionalDependencies:
+      '@types/node': 24.10.1
       fsevents: 2.3.3
 
-  vitest@1.6.1(jsdom@24.1.3):
+  vitest@1.6.1(@types/node@24.10.1)(jsdom@24.1.3):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -2659,10 +2675,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.21
-      vite-node: 1.6.1
+      vite: 5.4.21(@types/node@24.10.1)
+      vite-node: 1.6.1(@types/node@24.10.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 24.10.1
       jsdom: 24.1.3
     transitivePeerDependencies:
       - less

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Bundler",
     "lib": ["ES2022"],
     "strict": true,
     "declaration": true,
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx",
-    "allowImportingTsExtensions": true,
+    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "noEmitOnError": true,
     "useDefineForClassFields": true,


### PR DESCRIPTION
## Summary
- move the monorepo TypeScript configs to bundler resolution and remove test directories from build outputs
- adjust the web package config to include Node typings, streamline vitest settings, and keep build inputs under the project root
- export duel-snake types from the games package and update the web app imports/typing to consume the built entry

## Testing
- pnpm --filter @pvp-games/web build
- pnpm --filter @pvp-games/web test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692008b18ee083318efe0de26d31784d)