### PR TITLE
Create dedicated game pages for lobby entries

### DIFF
--- a/packages/web/app/components/site-footer.tsx
+++ b/packages/web/app/components/site-footer.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Link from 'next/link';
+
+import type { NavLink } from '../data/site';
+import { footerLinks } from '../data/site';
+
+function FooterLink({ link }: { link: NavLink }) {
+  const className =
+    'rounded-full px-3 py-2 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 transition hover:-translate-y-[1px] hover:bg-slate-50 hover:text-slate-900 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800 dark:hover:text-white';
+
+  if (link.external) {
+    return (
+      <a key={link.label} href={link.href} target="_blank" rel="noreferrer" className={className}>
+        {link.label}
+      </a>
+    );
+  }
+
+  return (
+    <Link key={link.label} href={link.href} className={className}>
+      {link.label}
+    </Link>
+  );
+}
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-base font-semibold text-slate-900 dark:text-slate-50">PVP 游戏大厅</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">精选对战玩法，跨平台轻量体验。</p>
+          <p className="text-xs text-slate-500 dark:text-slate-500">© {new Date().getFullYear()} PVP Game Hub</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {footerLinks.map((link) => (
+            <FooterLink key={link.label} link={link} />
+          ))}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/packages/web/app/components/site-header.tsx
+++ b/packages/web/app/components/site-header.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Link from 'next/link';
+
+import type { NavLink } from '../data/site';
+import { siteNavLinks } from '../data/site';
+
+function NavLinkItem({ link }: { link: NavLink }) {
+  const className =
+    'rounded-full px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-200 dark:hover:bg-slate-800 dark:hover:text-white dark:focus-visible:ring-offset-slate-900';
+
+  if (link.external) {
+    return (
+      <a href={link.href} target="_blank" rel="noreferrer" className={className}>
+        {link.label}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={link.href} className={className}>
+      {link.label}
+    </Link>
+  );
+}
+
+export function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-6 py-4">
+        <Link
+          href="/"
+          className="group flex items-center gap-2 rounded-full bg-slate-100 px-3 py-2 text-sm font-semibold text-slate-900 ring-1 ring-slate-200 transition hover:-translate-y-[1px] hover:bg-white hover:shadow-sm dark:bg-slate-800 dark:text-slate-50 dark:ring-slate-700 dark:hover:bg-slate-700"
+        >
+          <span className="rounded-full bg-sky-500/10 px-2 py-[6px] text-xs font-bold uppercase tracking-[0.18em] text-sky-700 ring-1 ring-sky-200 group-hover:bg-sky-500/15 dark:bg-sky-900/40 dark:text-sky-100 dark:ring-sky-800">
+            PVP
+          </span>
+          <span className="text-base">PVP 游戏大厅</span>
+        </Link>
+        <nav aria-label="主导航" className="flex flex-1 items-center justify-end gap-1">
+          {siteNavLinks.map((link) => (
+            <NavLinkItem key={link.label} link={link} />
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/packages/web/app/data/games.ts
+++ b/packages/web/app/data/games.ts
@@ -1,0 +1,44 @@
+import { getGameSummaries } from '@pvp-games/games';
+import { createSharedContext } from '@pvp-games/shared';
+import type { GameSummary } from '@pvp-games/games';
+
+export interface GameEntry extends GameSummary {
+  slug: string;
+}
+
+const fallbackCatalog: GameEntry[] = [
+  {
+    id: 'duel-snake',
+    slug: 'duel-snake',
+    title: 'Duel Snake (Local 2P)',
+    description: '本地双人同屏贪吃蛇对决：1P 方向键，2P WASD，先吃 10 果获胜。',
+    tags: ['local', '2p', 'snake'],
+    shared: createSharedContext({ project: 'pvp-games' })
+  }
+];
+
+let catalog: GameEntry[] | undefined;
+
+function loadCatalog(): GameEntry[] {
+  if (catalog) return catalog;
+
+  try {
+    catalog = getGameSummaries().map((game) => ({
+      ...game,
+      slug: game.id
+    }));
+  } catch (error) {
+    console.warn('Failed to load game summaries from @pvp-games/games, using fallback catalog', error);
+    catalog = fallbackCatalog;
+  }
+
+  return catalog;
+}
+
+export function listGameCatalog(): GameEntry[] {
+  return loadCatalog();
+}
+
+export function findGameBySlug(slug: string): GameEntry | undefined {
+  return loadCatalog().find((game) => game.slug === slug);
+}

--- a/packages/web/app/data/home.ts
+++ b/packages/web/app/data/home.ts
@@ -1,0 +1,40 @@
+import type { GameSummary } from '@pvp-games/games';
+
+export const hallHighlights = [
+  {
+    title: '零等待开局',
+    description: '无需下载，浏览器即可进入本地或在线对战。'
+  },
+  {
+    title: '每日推荐',
+    description: '根据游玩反馈轮换首页展示，让大厅保持新鲜。'
+  },
+  {
+    title: '共享引擎',
+    description: '核心玩法托管在 @pvp-games/games，前端按需加载。'
+  }
+];
+
+export const sidebarNotices = [
+  {
+    title: '周末蛇蛇积分赛',
+    description: '限定 10 回合，累计水果数排行，上榜即展示。',
+    tone: '活动'
+  },
+  {
+    title: '云对战大厅预告',
+    description: 'Sky Pong 与 Grid Rush 将接入匹配与观战。',
+    tone: '预告'
+  },
+  {
+    title: '征集玩法与素材',
+    description: '欢迎提交 Issue/PR，扩展地图皮肤或联机模式。',
+    tone: '社区'
+  }
+];
+
+const FEATURED_GAME_ID = 'duel-snake';
+
+export function pickFeaturedGame(games: GameSummary[]): GameSummary | undefined {
+  return games.find((game) => game.id === FEATURED_GAME_ID) ?? games[0];
+}

--- a/packages/web/app/data/site.ts
+++ b/packages/web/app/data/site.ts
@@ -1,0 +1,17 @@
+import type { Route } from 'next';
+
+type ExternalLink = { label: string; href: string; external: true };
+type InternalLink = { label: string; href: Route; external?: false };
+
+export type NavLink = ExternalLink | InternalLink;
+
+export const siteNavLinks: NavLink[] = [
+  { label: '首页', href: '/' },
+  { label: '全部游戏', href: '/#game-list' },
+  { label: '项目动态', href: 'https://github.com/pvp-games', external: true }
+];
+
+export const footerLinks: NavLink[] = [
+  { label: '开源仓库', href: 'https://github.com/pvp-games', external: true },
+  { label: '反馈建议', href: 'https://github.com/pvp-games/pvp-games/issues', external: true }
+];

--- a/packages/web/app/games/[gameId]/page.test.tsx
+++ b/packages/web/app/games/[gameId]/page.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+const mockGameSummaries = vi.fn(() => [
+  {
+    id: 'duel-snake',
+    title: 'Stub Duel Snake',
+    description: 'stub description',
+    tags: ['daily', 'local']
+  }
+]);
+
+vi.mock('@pvp-games/games', () => ({
+  DuelSnakeExperience: () => <div data-testid="duel-snake-experience" />,
+  getGameSummaries: mockGameSummaries
+}));
+
+let GamePage: typeof import('./page').default;
+let generateStaticParams: typeof import('./page').generateStaticParams;
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockGameSummaries.mockClear();
+  const mod = await import('./page');
+  GamePage = mod.default;
+  generateStaticParams = mod.generateStaticParams;
+});
+
+describe('GamePage', () => {
+  it('renders the requested game detail page and mounts the experience component', async () => {
+    render(await GamePage({ params: { gameId: 'duel-snake' } }));
+
+    expect(screen.getByRole('heading', { level: 1, name: /stub duel snake/i })).toBeInTheDocument();
+    expect(screen.getByText(/stub description/i)).toBeInTheDocument();
+    expect(screen.getByText('daily')).toBeInTheDocument();
+    expect(screen.getByText('local')).toBeInTheDocument();
+    expect(screen.getByTestId('duel-snake-experience')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /返回大厅/i })).toHaveAttribute('href', '/');
+  });
+
+  it('exports static params for every game slug in the catalog', async () => {
+    expect(generateStaticParams()).toEqual([{ gameId: 'duel-snake' }]);
+    expect(mockGameSummaries).toHaveBeenCalled();
+  });
+
+  it('falls back to a built-in catalog when summaries cannot be loaded', async () => {
+    mockGameSummaries.mockImplementationOnce(() => {
+      throw new Error('load failure');
+    });
+
+    render(await GamePage({ params: { gameId: 'duel-snake' } }));
+
+    expect(screen.getByRole('heading', { level: 1, name: /duel snake/i })).toBeInTheDocument();
+    expect(screen.getByText(/本地双人/i)).toBeInTheDocument();
+    expect(screen.getByTestId('duel-snake-experience')).toBeInTheDocument();
+  });
+});

--- a/packages/web/app/games/[gameId]/page.tsx
+++ b/packages/web/app/games/[gameId]/page.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { DuelSnakeExperience } from '@pvp-games/games';
+
+import { findGameBySlug, listGameCatalog } from '../../data/games';
+
+const experienceRegistry: Record<string, React.ReactNode> = {
+  'duel-snake': <DuelSnakeExperience />
+};
+
+interface GamePageProps {
+  params: Promise<{ gameId: string }>;
+}
+
+export function generateStaticParams() {
+  return listGameCatalog().map((game) => ({ gameId: game.slug }));
+}
+
+export const dynamicParams = false;
+
+export default async function GamePage({
+  params,
+}: GamePageProps) {
+  const { gameId } = await params;
+  const game = findGameBySlug(gameId);
+
+  if (!game) {
+    return notFound();
+  }
+
+  const experience = experienceRegistry[game.slug];
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 px-6 py-10">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-sm font-semibold text-sky-600">游戏详情</p>
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-50">{game.title}</h1>
+          {game.description && <p className="max-w-3xl text-base text-slate-600 dark:text-slate-300">{game.description}</p>}
+          <div className="flex flex-wrap gap-2">
+            {(game.tags ?? []).map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+        <Link
+          href="/"
+          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:-translate-y-[1px] hover:border-sky-200 hover:text-slate-900 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100"
+        >
+          返回大厅
+        </Link>
+      </div>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">玩法体验</p>
+            <p className="text-sm text-slate-600 dark:text-slate-300">具体对战体验在此页面加载，避免首页直接拉起。</p>
+          </div>
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700 ring-1 ring-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700">
+            {game.id}
+          </span>
+        </div>
+        {experience ?? (
+          <p className="text-sm text-slate-600 dark:text-slate-300">该游戏的对战体验即将上线，敬请期待。</p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/packages/web/app/layout.test.tsx
+++ b/packages/web/app/layout.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+
+import RootLayout from './layout';
+
+describe('RootLayout', () => {
+  it('renders shared site header and footer around the page', () => {
+    render(
+      <RootLayout>
+        <main>页面内容</main>
+      </RootLayout>
+    );
+
+    const header = screen.getByRole('banner');
+    expect(within(header).getByRole('link', { name: /pvp 游戏大厅/i })).toHaveAttribute('href', '/');
+    expect(within(header).getByRole('link', { name: /全部游戏/i })).toHaveAttribute('href', '/#game-list');
+
+    expect(screen.getByText('页面内容')).toBeInTheDocument();
+
+    const footer = screen.getByRole('contentinfo');
+    expect(within(footer).getByText(/©/)).toBeInTheDocument();
+  });
+});

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,5 +1,9 @@
+import React from 'react';
 import type { Metadata } from 'next';
 import './globals.css';
+
+import { SiteFooter } from './components/site-footer';
+import { SiteHeader } from './components/site-header';
 
 export const metadata: Metadata = {
   title: 'PVP 游戏大厅',
@@ -9,7 +13,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="zh-CN">
-      <body className="bg-slate-50 text-slate-900 antialiased dark:bg-slate-900 dark:text-slate-100">{children}</body>
+      <body className="bg-slate-50 text-slate-900 antialiased dark:bg-slate-900 dark:text-slate-100">
+        <div className="flex min-h-screen flex-col">
+          <SiteHeader />
+          <div className="flex-1">{children}</div>
+          <SiteFooter />
+        </div>
+      </body>
     </html>
   );
 }

--- a/packages/web/app/page.test.tsx
+++ b/packages/web/app/page.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import HomePage from './page';
-
 vi.mock('@pvp-games/games', () => ({
-  DuelSnakeExperience: () => <div data-testid="duel-snake-stub" />,
   getGameSummaries: () => [
     {
       id: 'duel-snake',
@@ -21,15 +18,17 @@ vi.mock('@pvp-games/games', () => ({
   ]
 }));
 
+import HomePage from './page';
+
 describe('HomePage', () => {
-  it('shows the hero CTA and highlights the daily pick from the games package', () => {
+  it('shows the hero CTA and links to the featured game page instead of直接开局', () => {
     render(<HomePage />);
 
     expect(screen.getByRole('heading', { level: 1, name: /pvp 游戏大厅/i })).toBeInTheDocument();
     expect(screen.getByText(/今日推荐 · Stub Duel Snake/i)).toBeInTheDocument();
     expect(screen.getByText(/共 2 款上架/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /立即开局/i })).toBeInTheDocument();
-    expect(screen.getByTestId('duel-snake-stub')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /立即开局/i })).toHaveAttribute('href', '/games/duel-snake');
+    expect(screen.queryByTestId('duel-snake-stub')).not.toBeInTheDocument();
   });
 
   it('renders all game cards from the library', () => {
@@ -37,5 +36,6 @@ describe('HomePage', () => {
 
     expect(screen.getAllByText('Stub Duel Snake')).not.toHaveLength(0);
     expect(screen.getByText('Sky Pong')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /进入游戏/i })[0]).toHaveAttribute('href', '/games/duel-snake');
   });
 });

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,43 +1,13 @@
 import React from 'react';
-import { DuelSnakeExperience, getGameSummaries } from '@pvp-games/games';
+import Link from 'next/link';
 
-const hallHighlights = [
-  {
-    title: '零等待开局',
-    description: '无需下载，浏览器即可进入本地或在线对战。'
-  },
-  {
-    title: '每日推荐',
-    description: '根据游玩反馈轮换首页展示，让大厅保持新鲜。'
-  },
-  {
-    title: '共享引擎',
-    description: '核心玩法托管在 @pvp-games/games，前端按需加载。'
-  }
-];
+import { hallHighlights, pickFeaturedGame, sidebarNotices } from './data/home';
+import { listGameCatalog } from './data/games';
 
-const sidebarNotices = [
-  {
-    title: '周末蛇蛇积分赛',
-    description: '限定 10 回合，累计水果数排行，上榜即展示。',
-    tone: '活动'
-  },
-  {
-    title: '云对战大厅预告',
-    description: 'Sky Pong 与 Grid Rush 将接入匹配与观战。',
-    tone: '预告'
-  },
-  {
-    title: '征集玩法与素材',
-    description: '欢迎提交 Issue/PR，扩展地图皮肤或联机模式。',
-    tone: '社区'
-  }
-];
-
-const games = getGameSummaries();
+const games = listGameCatalog();
 
 export default function HomePage() {
-  const duelSnake = games.find((game) => game.id === 'duel-snake') ?? games[ 0 ];
+  const duelSnake = pickFeaturedGame(games);
 
   return (
     <main className="mx-auto max-w-6xl space-y-10 px-6 py-10">
@@ -71,18 +41,20 @@ export default function HomePage() {
             </div>
 
             <div className="flex flex-wrap gap-3">
-              <button
-                type="button"
-                className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-lg ring-1 ring-white/60 transition hover:-translate-y-[1px] hover:shadow-xl"
-              >
-                立即开局
-              </button>
-              <button
-                type="button"
+              {duelSnake && (
+                <Link
+                  href={`/games/${duelSnake.id}`}
+                  className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-lg ring-1 ring-white/60 transition hover:-translate-y-[1px] hover:shadow-xl"
+                >
+                  立即开局
+                </Link>
+              )}
+              <Link
+                href="#game-list"
                 className="rounded-full bg-transparent px-4 py-2 text-sm font-semibold text-white ring-1 ring-white/40 transition hover:-translate-y-[1px] hover:bg-white/10"
               >
                 查看全部游戏
-              </button>
+              </Link>
             </div>
           </div>
 
@@ -94,17 +66,30 @@ export default function HomePage() {
                 <p className="text-sm text-white/80">{duelSnake?.description ?? '本地双人对战，开局即战。'}</p>
               </div>
               <span className="rounded-full bg-slate-900/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide ring-1 ring-white/15">
-                from games package
+                独立游戏页
               </span>
             </div>
-            <div className="mt-4 overflow-hidden rounded-xl bg-slate-950/40 ring-1 ring-white/10">
-              <DuelSnakeExperience />
+            <div className="mt-4 rounded-xl bg-slate-950/40 p-4 ring-1 ring-white/10">
+              <p className="text-sm text-white/80">进入专属游戏页即可启动对战体验，首页保持轻量展示。</p>
+              {duelSnake && (
+                <div className="mt-3 flex flex-wrap items-center gap-3">
+                  <Link
+                    href={`/games/${duelSnake.id}`}
+                    className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-lg ring-1 ring-white/60 transition hover:-translate-y-[1px] hover:shadow-xl"
+                  >
+                    前往 {duelSnake.title}
+                  </Link>
+                  <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white/90 ring-1 ring-white/20">
+                    {duelSnake.tags?.join(' · ') ?? 'PVP'}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         </div>
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
+      <section id="game-list" className="grid gap-6 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="space-y-1">
@@ -143,6 +128,15 @@ export default function HomePage() {
                       {tag}
                     </span>
                   ))}
+                </div>
+                <div className="mt-4 flex items-center justify-between">
+                  <Link
+                    href={`/games/${game.id}`}
+                    className="rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-[1px] hover:bg-sky-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+                  >
+                    进入游戏
+                  </Link>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">独立页面加载对战体验</span>
                 </div>
               </article>
             ))}

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack -p 3020",
     "build": "next build",
     "lint": "eslint . --fix",
     "test": "vitest run",
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@pvp-games/games": "workspace:^",
+    "@pvp-games/shared": "workspace:^",
     "next": "^16.0.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@pvp-games/games':
         specifier: workspace:^
         version: link:../games
+      '@pvp-games/shared':
+        specifier: workspace:^
+        version: link:../shared
       next:
         specifier: ^16.0.3
         version: 16.0.3(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
## Summary
- move lobby copy and game catalog metadata into shared data modules and link CTAs to per-game routes
- add a dedicated game detail page that renders the DuelSnake experience away from the lobby
- cover the new navigation and game page rendering paths with Vitest suites

## Testing
- pnpm --filter @pvp-games/web test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209296438083318874115a35c002c3)