### PR TITLE
Update netplay plan for Cloudflare Durable Objects

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,8 @@
 
 ## 网络方案
 - **WebRTC + 服务器协助信令：** 客户端通过轻量信令服务（HTTP 或 WebSocket）建立会话、匹配玩家并交换 ICE；建立后走点对点 DataChannel 传输游戏数据。
-- **TURN/STUN 兜底：** 默认直连，必要时使用配置好的 STUN/TURN 以穿透 NAT/防火墙。
+- **Cloudflare Durable Object 作为信令/中转：** 以 Durable Object 房间实例管理玩家列表、就绪状态与 ICE/offer/answer 交换；同一实例同时提供 WebSocket Relay 兜底，当 WebRTC 失败或受限时转为有序广播。
+- **TURN/STUN 兜底：** 默认直连，必要时使用配置好的 STUN/TURN（含 Google STUN）以穿透 NAT/防火墙。
 - **消息封装：** 采用带版本号的 JSON 信封，配合共享模块的模式校验，保证客户端与服务器兼容。
 
 ## 模块职责
@@ -32,3 +33,21 @@
 - 里程碑 3：Snake 确定性引擎（网格、食物、碰撞、计分），含支持回滚的状态 diff 测试。
 - 里程碑 4：客户端 UI（输入缓冲、渲染循环）与跨端同步验证。
 - 里程碑 5：遥测、重连/观战支持与赛后总结。
+
+## 联网对战实施计划（Cloudflare Durable Object）
+围绕“先设计 → 写测试 → 再编码”的流程，将联网模块拆解为以下阶段（每阶段结束都执行对应测试）：
+
+1. **契约与房间设计（文档阶段）**：
+   - 定义 Durable Object 房间模型：房间 UUID、玩家槽位、ready 状态、WebRTC 信令缓冲、Relay 队列。
+   - 设计消息协议（版本号、动作类型、负载结构）与错误码，区分 WebRTC 信令与 WebSocket Relay 载荷。
+   - 规划前端共享 SDK（`packages/netplay`）的 API：创建/加入房间、ready/start 流程、事件订阅。
+
+2. **测试编写阶段**：
+   - 在共享模块添加协议与状态机的类型/运行时模式测试，确保房间生命周期、信令与回退路径可验证。
+   - 为 Durable Object Handler 写单元/集成测试：创建房间、两端加入、信令转发、WebSocket Relay 透传、异常恢复。
+   - 前端 hook/Provider 的契约测试：模拟房间创建分享链接、双方 ready 后触发 start 事件。
+
+3. **编码与集成阶段**：
+   - 实现 `packages/netplay` SDK：封装 WebRTC（Google STUN 默认，可配置 TURN）、信令消息编解码、WebSocket Relay 回退。
+   - 在 Cloudflare Worker/Durable Object 中落地房间逻辑与信令/Relay 端点，提供 HTTP 创建链接与 WebSocket 接入。
+   - 将 Duel Snake 等游戏接入 SDK，打通“创建链接 → 分享 → 双方开始”完整链路，并补充 README/TESTING。


### PR DESCRIPTION
## Summary
- update network architecture to adopt Cloudflare Durable Objects for signaling and WebSocket relay fallback
- outline phased plan covering contract design, testing, and implementation for the shared netplay module

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216fa110948331bf3938d38064977b)